### PR TITLE
Fix compilation warning

### DIFF
--- a/cmd/nocc.cpp
+++ b/cmd/nocc.cpp
@@ -127,7 +127,9 @@ void start_daemon_in_background() {
   }
 
   int pipd[2];
-  pipe(pipd);
+  if (pipe(pipd) == -1) {
+    execute_cxx_locally("could not start daemon", errno);
+  };
 
   int pid = fork();
   if (pid < 0) {


### PR DESCRIPTION
```
user@o0004238:~/nocc$ make client
go build -o bin/nocc-daemon -trimpath -ldflags '-s -w -X "github.com/VKCOM/nocc/internal/common.version=v1.2, rev 73b26e5, compiled at 2023-05-23 21:54:34 UTC"' cmd/nocc-daemon/main.go
g++ -std=c++11 -O3 cmd/nocc.cpp -o bin/nocc
cmd/nocc.cpp: In function ‘void start_daemon_in_background()’:
cmd/nocc.cpp:130:7: warning: ignoring return value of ‘int pipe(int*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  130 |   pipe(pipd);
      |   ~~~~^~~~~~
```