### PR TITLE
Proof of concept for windows compilation (do not merge)

### DIFF
--- a/internal/client/daemon.go
+++ b/internal/client/daemon.go
@@ -139,9 +139,10 @@ func (daemon *Daemon) StartListeningUnixSocket(daemonUnixSock string) error {
 func (daemon *Daemon) ServeUntilNobodyAlive() {
 	logClient.Info(0, "nocc-daemon started in", time.Since(daemon.startTime).Milliseconds(), "ms")
 
-	var rLimit syscall.Rlimit
-	_ = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-	logClient.Info(0, "env:", "clientID", daemon.clientID, "; user", daemon.hostUserName, "; num servers", len(daemon.remoteConnections), "; ulimit -n", rLimit.Cur, "; num cpu", runtime.NumCPU(), "; version", common.GetVersion())
+	// var rLimit syscall.Rlimit
+	// _ = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	// logClient.Info(0, "env:", "clientID", daemon.clientID, "; user", daemon.hostUserName, "; num servers", len(daemon.remoteConnections), "; ulimit -n", rLimit.Cur, "; num cpu", runtime.NumCPU(), "; version", common.GetVersion())
+	logClient.Info(0, "env:", "clientID", daemon.clientID, "; user", daemon.hostUserName, "; num servers", len(daemon.remoteConnections), "; num cpu", runtime.NumCPU(), "; version", common.GetVersion())
 
 	go daemon.PeriodicallyInterruptHangedInvocations()
 	go daemon.listener.StartAcceptingConnections(daemon)

--- a/internal/server/cron.go
+++ b/internal/server/cron.go
@@ -40,7 +40,7 @@ func (c *Cron) doCron() {
 			select {
 			case sig := <-c.signals:
 				logServer.Info(0, "got signal", sig)
-				if sig == syscall.SIGUSR1 {
+				if false { //sig == syscall.SIGUSR1 {
 					if err := logServer.RotateLogFile(); err != nil {
 						logServer.Error("could not rotate log file", err)
 					} else {
@@ -59,7 +59,8 @@ func (c *Cron) doCron() {
 
 func (c *Cron) StartCron() {
 	c.signals = make(chan os.Signal, 2)
-	signal.Notify(c.signals, syscall.SIGUSR1, syscall.SIGTERM)
+	// signal.Notify(c.signals, syscall.SIGUSR1, syscall.SIGTERM)
+	signal.Notify(c.signals, syscall.SIGTERM)
 	c.doCron()
 }
 

--- a/internal/server/nocc-server.go
+++ b/internal/server/nocc-server.go
@@ -12,7 +12,8 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
-	"syscall"
+
+	// "syscall"
 	"time"
 
 	"github.com/VKCOM/nocc/internal/common"
@@ -62,9 +63,10 @@ func (s *NoccServer) StartGRPCListening(listenAddr string) (net.Listener, error)
 
 	logServer.Info(0, "nocc-server started")
 
-	var rLimit syscall.Rlimit
-	_ = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
-	logServer.Info(0, "env:", "listenAddr", listenAddr, "; ulimit -n", rLimit.Cur, "; num cpu", runtime.NumCPU(), "; version", common.GetVersion())
+	// var rLimit syscall.Rlimit
+	// _ = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	// logServer.Info(0, "env:", "listenAddr", listenAddr, "; ulimit -n", rLimit.Cur, "; num cpu", runtime.NumCPU(), "; version", common.GetVersion())
+	logServer.Info(0, "env:", "listenAddr", listenAddr, "; num cpu", runtime.NumCPU(), "; version", common.GetVersion())
 
 	return listener, s.GRPCServer.Serve(listener)
 }
@@ -371,8 +373,8 @@ func (s *NoccServer) Status(context.Context, *pb.StatusRequest) (*pb.StatusReply
 	clangRawOut, _ := exec.Command("clang", "-v").CombinedOutput()
 	uNameRV, _ := exec.Command("uname", "-rv").CombinedOutput()
 
-	var rLimit syscall.Rlimit
-	_ = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
+	// var rLimit syscall.Rlimit
+	// _ = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 
 	return &pb.StatusReply{
 		ServerVersion:   common.GetVersion(),
@@ -383,7 +385,7 @@ func (s *NoccServer) Status(context.Context, *pb.StatusRequest) (*pb.StatusReply
 		LogFileSize:     logServer.GetFileSize(),
 		SrcCacheSize:    s.SrcFileCache.GetBytesOnDisk(),
 		ObjCacheSize:    s.ObjFileCache.GetBytesOnDisk(),
-		ULimit:          int64(rLimit.Cur),
+		ULimit:          int64(65535),
 		UName:           strings.TrimSpace(string(uNameRV)),
 		SessionsTotal:   atomic.LoadInt64(&s.Stats.sessionsCount),
 		SessionsActive:  s.ActiveClients.ActiveSessionsCount(),


### PR DESCRIPTION
Environment: 
Windows 10
Go 1.18 windows/amd64
MSYS64 (https://www.msys2.org/) with installation make and gcc package 
```
pacman -S make
pacman -S gcc
```
Do not forget add path to go binary, check with
```
$ go version
go version go1.18.10 windows/amd64
```
Result:
```
$ bin/nocc-server
2023-05-24 01:52:42 INFO nocc-server started
2023-05-24 01:52:43 INFO env: listenAddr 0.0.0.0:43210 ; num cpu 12 ; version v1.2, rev 73b26e5, compiled at 2023-05-23 22:36:47 UTC
2023-05-24 01:53:35 INFO new client clientID eWPbFcXn version Unknown ; nClients 1
2023-05-24 01:53:35 INFO new remotes list 1 clientID eWPbFcXn 127.0.0.1
2023-05-24 01:53:36 ERROR can't create dir /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src mkdir /tmp/nocc/cpp/clients/eWPbFcXn/K:: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 ERROR can't create dir /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests mkdir /tmp/nocc/cpp/clients/eWPbFcXn/K:: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 INFO started sessionID 1 clientID eWPbFcXn waiting 6 uploads dt/cmake1/src/main.cpp
2023-05-24 01:53:36 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/cmake1/src/all-headers.h open /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src/all-headers.h.5577006791947779410: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/cmake1/src/my-math.h open /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src/my-math.h.8674665223082153551: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/cmake1/src/my-strings.h open /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src/my-strings.h.6129484611666145821: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/cmake1/src/my-warning.h open /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src/my-warning.h.4037200794235010051: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/cmake1/src/empty.h open /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src/empty.h.3916589616287113937: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/cmake1/src/main.cpp open /tmp/nocc/cpp/clients/eWPbFcXn/K:\nocc\tests/dt/cmake1/src/main.cpp.6334824724549167320: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:36 INFO client disconnected clientID eWPbFcXn ; nClients 0
2023-05-24 01:53:36 INFO new client clientID eCjCcWIC version v1.2, rev 73b26e5, compiled at 2023-05-23 22:30:47 UTC ; nClients 1
2023-05-24 01:53:37 INFO new client clientID VbnItEdo version Unknown ; nClients 2
2023-05-24 01:53:37 ERROR can't create dir /tmp/nocc/cpp/clients/VbnItEdo/K:\nocc\tests/dt mkdir /tmp/nocc/cpp/clients/VbnItEdo/K:: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:37 ERROR can't create dir /tmp/nocc/cpp/clients/VbnItEdo/K:\nocc\tests mkdir /tmp/nocc/cpp/clients/VbnItEdo/K:: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:37 INFO started sessionID 1 clientID VbnItEdo waiting 1 uploads dt/path-macro.cpp
2023-05-24 01:53:37 ERROR fs uploading->error sessionID 1 /K:\nocc\tests/dt/path-macro.cpp open /tmp/nocc/cpp/clients/VbnItEdo/K:\nocc\tests/dt/path-macro.cpp.605394647632969758: The filename, directory name, or volume label syntax is incorrect.
2023-05-24 01:53:37 INFO client disconnected clientID VbnItEdo ; nClients 1
2023-05-24 01:53:51 INFO client disconnected clientID eCjCcWIC ; nClients 0
```


