### PR TITLE
improvement clang support: normalization of paths for isystem

### DIFF
--- a/internal/client/includes-collector.go
+++ b/internal/client/includes-collector.go
@@ -231,7 +231,12 @@ func parseCxxDefaultIncludeDirsFromWpStderr(cxxWpStderr string) IncludeDirs {
 				cxxDefIncludeDirs.dirsIquote = append(cxxDefIncludeDirs.dirsIquote, line)
 			case stateInDirsI:
 				if strings.HasPrefix(line, "/usr/") || strings.HasPrefix(line, "/Library/") {
-					cxxDefIncludeDirs.dirsIsystem = append(cxxDefIncludeDirs.dirsIsystem, line)
+					normalizedPath, err := filepath.Abs(line)
+					if err != nil {
+						logClient.Error("can't normalize path:", line)
+						continue
+					}
+					cxxDefIncludeDirs.dirsIsystem = append(cxxDefIncludeDirs.dirsIsystem, normalizedPath)
 				} else {
 					cxxDefIncludeDirs.dirsI = append(cxxDefIncludeDirs.dirsI, line)
 				}
@@ -266,6 +271,7 @@ func extractIncludesFromCxxMStdout(cxxMStdout []byte) []string {
 
 // CompareOwnIncludesParserAndCxxM is for development purposes.
 // Perform a full-text search for this method call.
+//
 //goland:noinspection GoUnusedExportedFunction
 func CompareOwnIncludesParserAndCxxM(cppInFile string, ownFoundHFiles []IncludedFile, cxxMFoundHFiles []IncludedFile) bool {
 	equal := true

--- a/internal/server/nocc-server.go
+++ b/internal/server/nocc-server.go
@@ -217,7 +217,7 @@ func (s *NoccServer) UploadFileStream(stream pb.CompilationService_UploadFileStr
 	for {
 		firstChunk, err := stream.Recv()
 		if err != nil {
-			if stream.Context().Err() != context.Canceled {
+			if !errors.Is(stream.Context().Err(), context.Canceled) {
 				logServer.Error("stream receive error:", err.Error())
 			}
 			return err


### PR DESCRIPTION
We use $CXX -Wp,-v -x c++ /dev/null -fsyntax-only to obtain the paths where we can search for system header files. For the clang compiler, the paths appear as follows:
```
 /usr/bin/../lib/gcc/aarch64-linux-gnu/10/../../../../include/c++/10
 /usr/bin/../lib/gcc/aarch64-linux-gnu/10/../../../../include/aarch64-linux-gnu/c++/10
 /usr/bin/../lib/gcc/aarch64-linux-gnu/10/../../../../include/c++/10/backward
 /usr/lib/llvm-18/lib/clang/18/include
 /usr/local/include
 /usr/include/aarch64-linux-gnu
 /usr/include
```
As we can see, the first three paths are not absolute. This means that in order to access the "/usr/bin/../lib/" path on the nocc server, we need a directory called "/usr/bin" within the source prefix directory, but we do not have it. As a result, it will skip these paths.

I think the best solution is to normalize the paths provided by the compiler.